### PR TITLE
Provide hasMark methods (with a not-used function)

### DIFF
--- a/lua/core/card.lua
+++ b/lua/core/card.lua
@@ -331,7 +331,7 @@ end
 ---@param mark string @ 标记
 ---@return boolean
 function Card:hasMark(mark)
-  return (self.mark[mark] or 0) ~= 0 --self.mark.hasKey(mark)
+  return self:getMark(mark) ~= 0 --self.mark.hasKey(mark)
 end
 
 --- 获取卡牌有哪些Mark。

--- a/lua/core/card.lua
+++ b/lua/core/card.lua
@@ -322,9 +322,16 @@ end
 
 --- 获取卡牌对应Mark的数量。
 ---@param mark string @ 标记
----@param count integer @ 为标记删除的数量
+---@return integer
 function Card:getMark(mark)
   return (self.mark[mark] or 0)
+end
+
+--- 判定卡牌是否拥有对应的Mark。
+---@param mark string @ 标记
+---@return boolean
+function Card:hasMark(mark)
+  return (self.mark[mark] or 0) ~= 0 --self.mark.hasKey(mark)
 end
 
 --- 获取卡牌有哪些Mark。

--- a/lua/core/player.lua
+++ b/lua/core/player.lua
@@ -201,7 +201,7 @@ end
 ---@param mark string @ 标记
 ---@return boolean
 function Player:hasMark(mark)
-  return (self.mark[mark] or 0) ~= 0 --self.mark.hasKey(mark)
+  return self:getMark(mark) ~= 0 --self.mark.hasKey(mark)
 end
 
 --- 获取角色有哪些Mark。

--- a/lua/core/player.lua
+++ b/lua/core/player.lua
@@ -192,9 +192,16 @@ end
 
 --- 获取角色对应Mark的数量。
 ---@param mark string @ 标记
----@param count integer @ 为标记删除的数量
+---@return integer
 function Player:getMark(mark)
   return (self.mark[mark] or 0)
+end
+
+--- 判定角色是否拥有对应的Mark。
+---@param mark string @ 标记
+---@return boolean
+function Player:hasMark(mark)
+  return (self.mark[mark] or 0) ~= 0 --self.mark.hasKey(mark)
 end
 
 --- 获取角色有哪些Mark。

--- a/lua/core/util.lua
+++ b/lua/core/util.lua
@@ -84,11 +84,20 @@ function table.reverse(self)
   return ret
 end
 
+function table:hasKey(key)
+  if #self == 0 then return false end
+  for k, _ in ipairs(self) do
+    if k == key then return true end
+  end
+  return false
+end
+
 function table:contains(element)
   if #self == 0 then return false end
   for _, e in ipairs(self) do
     if e == element then return true end
   end
+  return false
 end
 
 function table:shuffle()


### PR DESCRIPTION
It provides two methods `Player:hasMark` and `Card:hasMark` for determining if the player/card has the mark, which is more expressive than `xxx:getMark` when only checking for the existence.

By the way, xxx:hasMark may directly determine a `Mark` in xxx.mark, for which I added `table:hasKey` method in `util.lua`, but currently the code still checks if the result of `xxx:getMark` is not 0.

---

提供了`Player:hasMark`和`Card:hasMark`两个方法，用于在只需要判断是否有标记时可以直接使用`xxx:hasMark`，相比使用`xxx:getMark`而言更加表达代码的作用。

顺带一提，`xxx:hasMark`应该可以直接判断`Mark`是否在`xxx.mark`里，我在`util.lua`里添加了`table:hasKey`的方法用于判断，但目前的代码还是判断`xxx:getMark`的结果是否不为0。