### PR TITLE
Nfeature

### DIFF
--- a/Fk/LobbyElement/RoomPackageSettings.qml
+++ b/Fk/LobbyElement/RoomPackageSettings.qml
@@ -9,6 +9,7 @@ Flickable {
   flickableDirection: Flickable.AutoFlickIfNeeded
   clip: true
   contentHeight: layout.height
+  property bool loading: false
   ScrollBar.vertical: ScrollBar {
     parent: root.parent
     anchors.top: root.top
@@ -65,7 +66,9 @@ Flickable {
           enabled: orig_name !== "test_p_0"
 
           onCheckedChanged: {
-            checkPackage(orig_name, checked);
+            if (!loading) {
+              checkPackage(orig_name, checked);
+            }
           }
         }
       }
@@ -130,6 +133,7 @@ Flickable {
   }
 
   Component.onCompleted: {
+    loading = true;
     const g = JSON.parse(Backend.callLuaFunction("GetAllGeneralPack", []));
     for (let orig of g) {
       if (config.serverHiddenPacks.includes(orig)) {
@@ -153,5 +157,6 @@ Flickable {
         pkg_enabled: !config.disabledPack.includes(orig),
       });
     }
+    loading = false;
   }
 }

--- a/Fk/Pages/Room.qml
+++ b/Fk/Pages/Room.qml
@@ -21,6 +21,7 @@ Item {
   property bool isFull: false
   property bool isAllReady: false
   property bool isReady: false
+  property bool canKickOwner: false
 
   property alias popupBox: popupBox
   property alias manualBox: manualBox
@@ -71,6 +72,8 @@ Item {
   onIsStartedChanged: {
     if (isStarted) {
       bgm.play();
+      canKickOwner = false;
+      kickOwnerTimer.stop();
     } else {
       // bgm.stop();
     }
@@ -209,6 +212,40 @@ Item {
       ClientInstance.notifyServer("Ready", "");
     }
   }
+
+  Button {
+    id: kickOwner
+    anchors.horizontalCenter: parent.horizontalCenter
+    y: parent.height / 2 + 30
+    text: "踢出房主"
+    visible: canKickOwner && !isStarted && isFull && !isOwner
+    onClicked: {
+      for (let i = 0; i < photoModel.count; i++) {
+        let item = photoModel.get(i);
+        if (item.isOwner) {
+          ClientInstance.notifyServer("KickPlayer", item.id.toString());
+        }
+      }
+    }
+  }
+
+  Timer {
+    id: kickOwnerTimer
+    interval: 15000
+    onTriggered: {
+      canKickOwner = true;
+    }
+  }
+
+  onIsAllReadyChanged: {
+    if (!isAllReady) {
+      canKickOwner = false;
+      kickOwnerTimer.stop();
+    } else {
+      kickOwnerTimer.start();
+    }
+  }
+
   Rectangle {
     x: parent.width / 2 + 60
     y: parent.height / 2 - 30

--- a/lua/client/client.lua
+++ b/lua/client/client.lua
@@ -60,6 +60,7 @@ function Client:initialize()
   self.skill_costs = {}
   self.card_marks = {}
   self.filtered_cards = {}
+  self.printed_cards = {}
   self.disabled_packs = {}
   self.disabled_generals = {}
 
@@ -930,6 +931,13 @@ fk.client_callback["EnterLobby"] = function(jsonData)
   end
   --]]
   c:notifyUI("EnterLobby", jsonData)
+end
+
+fk.client_callback["PrintCard"] = function(j)
+  local data = json.decode(j)
+  local n, s, num = table.unpack(data)
+  local cd = Fk:cloneCard(n, s, num)
+  Fk:_addPrintedCard(cd)
 end
 
 -- Create ClientInstance (used by Lua)

--- a/lua/core/card.lua
+++ b/lua/core/card.lua
@@ -153,7 +153,7 @@ end
 
 --- 检测是否为虚拟卡牌，如果其ID为0及以下，则为虚拟卡牌。
 function Card:isVirtual()
-  return self.id <= 0
+  return self.id == 0
 end
 
 --- 获取卡牌的ID。

--- a/lua/fk_ex.lua
+++ b/lua/fk_ex.lua
@@ -191,7 +191,7 @@ function fk.CreateActiveSkill(spec)
   if spec.target_filter then skill.targetFilter = spec.target_filter end
   if spec.mod_target_filter then skill.modTargetFilter = spec.mod_target_filter end
   if spec.feasible then
-    print(spec.name .. ": feasible is deprecated. Use target_num and card_num instead.")
+    -- print(spec.name .. ": feasible is deprecated. Use target_num and card_num instead.")
     skill.feasible = spec.feasible
   end
   if spec.on_use then skill.onUse = spec.on_use end

--- a/lua/server/events/death.lua
+++ b/lua/server/events/death.lua
@@ -2,67 +2,68 @@
 
 GameEvent.functions[GameEvent.Dying] = function(self)
   local dyingStruct = table.unpack(self.data)
-  local self = self.room
-  local dyingPlayer = self:getPlayerById(dyingStruct.who)
+  local room = self.room
+  local logic = room.logic
+  local dyingPlayer = room:getPlayerById(dyingStruct.who)
   dyingPlayer.dying = true
-  self:broadcastProperty(dyingPlayer, "dying")
-  self:sendLog{
+  room:broadcastProperty(dyingPlayer, "dying")
+  room:sendLog{
     type = "#EnterDying",
     from = dyingPlayer.id,
   }
-  self.logic:trigger(fk.EnterDying, dyingPlayer, dyingStruct)
+  logic:trigger(fk.EnterDying, dyingPlayer, dyingStruct)
 
   if dyingPlayer.hp < 1 then
-    -- self.logic:trigger(fk.Dying, dyingPlayer, dyingStruct)
-    local savers = self:getAlivePlayers()
+    -- room.logic:trigger(fk.Dying, dyingPlayer, dyingStruct)
+    local savers = room:getAlivePlayers()
     for _, p in ipairs(savers) do
-      if dyingPlayer.hp > 0 or dyingPlayer.dead or self.logic:trigger(fk.AskForPeaches, p, dyingStruct) then
+      if dyingPlayer.hp > 0 or dyingPlayer.dead or logic:trigger(fk.AskForPeaches, p, dyingStruct) then
         break
       end
     end
-    self.logic:trigger(fk.AskForPeachesDone, dyingPlayer, dyingStruct)
+    logic:trigger(fk.AskForPeachesDone, dyingPlayer, dyingStruct)
   end
 
   if not dyingPlayer.dead and dyingPlayer.dying then
     dyingPlayer.dying = false
-    self:broadcastProperty(dyingPlayer, "dying")
+    room:broadcastProperty(dyingPlayer, "dying")
   end
-  self.logic:trigger(fk.AfterDying, dyingPlayer, dyingStruct)
+  logic:trigger(fk.AfterDying, dyingPlayer, dyingStruct)
 end
 
 GameEvent.functions[GameEvent.Death] = function(self)
   local deathStruct = table.unpack(self.data)
-  local self = self.room
-  local victim = self:getPlayerById(deathStruct.who)
+  local room = self.room
+  local victim = room:getPlayerById(deathStruct.who)
   victim.dead = true
   victim._splayer:setDied(true)
-  table.removeOne(self.alive_players, victim)
+  table.removeOne(room.alive_players, victim)
 
-  local logic = self.logic
+  local logic = room.logic
   logic:trigger(fk.BeforeGameOverJudge, victim, deathStruct)
 
   local killer = deathStruct.damage and deathStruct.damage.from or nil
   if killer then
-    self:sendLog{
+    room:sendLog{
       type = "#KillPlayer",
       to = {killer.id},
       from = victim.id,
       arg = victim.role,
     }
   else
-    self:sendLog{
+    room:sendLog{
       type = "#KillPlayerWithNoKiller",
       from = victim.id,
       arg = victim.role,
     }
   end
-  self:sendLogEvent("Death", {to = victim.id})
+  room:sendLogEvent("Death", {to = victim.id})
 
-  self:broadcastProperty(victim, "role")
-  self:broadcastProperty(victim, "dead")
+  room:broadcastProperty(victim, "role")
+  room:broadcastProperty(victim, "dead")
 
   victim.drank = 0
-  self:broadcastProperty(victim, "drank")
+  room:broadcastProperty(victim, "drank")
 
   logic:trigger(fk.GameOverJudge, victim, deathStruct)
   logic:trigger(fk.Death, victim, deathStruct)

--- a/lua/server/events/judge.lua
+++ b/lua/server/events/judge.lua
@@ -2,69 +2,70 @@
 
 GameEvent.functions[GameEvent.Judge] = function(self)
   local data = table.unpack(self.data)
-  local self = self.room
+  local room = self.room
+  local logic = room.logic
   local who = data.who
-  self.logic:trigger(fk.StartJudge, who, data)
-  data.card = data.card or Fk:getCardById(self:getNCards(1)[1])
+  logic:trigger(fk.StartJudge, who, data)
+  data.card = data.card or Fk:getCardById(room:getNCards(1)[1])
 
   if data.reason ~= "" then
-    self:sendLog{
+    room:sendLog{
       type = "#StartJudgeReason",
       from = who.id,
       arg = data.reason,
     }
   end
 
-  self:sendLog{
+  room:sendLog{
     type = "#InitialJudge",
     from = who.id,
     card = {data.card.id},
   }
-  self:moveCardTo(data.card, Card.Processing, nil, fk.ReasonJudge)
-  self:sendFootnote({ data.card.id }, {
+  room:moveCardTo(data.card, Card.Processing, nil, fk.ReasonJudge)
+  room:sendFootnote({ data.card.id }, {
     type = "##JudgeCard",
     arg = data.reason,
   })
 
-  self.logic:trigger(fk.AskForRetrial, who, data)
-  self.logic:trigger(fk.FinishRetrial, who, data)
+  logic:trigger(fk.AskForRetrial, who, data)
+  logic:trigger(fk.FinishRetrial, who, data)
   Fk:filterCard(data.card.id, who, data)
-  self:sendLog{
+  room:sendLog{
     type = "#JudgeResult",
     from = who.id,
     card = {data.card.id},
   }
-  self:sendFootnote({ data.card.id }, {
+  room:sendFootnote({ data.card.id }, {
     type = "##JudgeCard",
     arg = data.reason,
   })
 
   if data.pattern then
-    self:delay(400);
-    self:setCardEmotion(data.card.id, data.card:matchPattern(data.pattern) and "judgegood" or "judgebad")
-    self:delay(900);
+    room:delay(400);
+    room:setCardEmotion(data.card.id, data.card:matchPattern(data.pattern) and "judgegood" or "judgebad")
+    room:delay(900);
   end
 
-  if self.logic:trigger(fk.FinishJudge, who, data) then
-    self.logic:breakEvent()
+  if logic:trigger(fk.FinishJudge, who, data) then
+    logic:breakEvent()
   end
 end
 
 GameEvent.cleaners[GameEvent.Judge] = function(self)
   local data = table.unpack(self.data)
-  local self = self.room
-  if (self.interrupted or not data.skipDrop) and self:getCardArea(data.card.id) == Card.Processing then
-    self:moveCardTo(data.card, Card.DiscardPile, nil, fk.ReasonJudge)
+  local room = self.room
+  if (self.interrupted or not data.skipDrop) and room:getCardArea(data.card.id) == Card.Processing then
+    room:moveCardTo(data.card, Card.DiscardPile, nil, fk.ReasonJudge)
   end
   if not self.interrupted then return end
 
   -- prohibit access to judge.card
   setmetatable(data, {
-    __index = function(self, key)
+    __index = function(s, key)
       if key == "card" then
         error("__manuallyBreak")
       end
-      return rawget(self, key)
+      return rawget(s, key)
     end
   })
 end

--- a/lua/server/events/movecard.lua
+++ b/lua/server/events/movecard.lua
@@ -2,7 +2,7 @@
 
 GameEvent.functions[GameEvent.MoveCards] = function(self)
   local args = self.data
-  local self = self.room
+  local room = self.room
   ---@type CardsMoveStruct[]
   local cardsMoveStructs = {}
   local infoCheck = function(info)
@@ -20,8 +20,8 @@ GameEvent.functions[GameEvent.MoveCards] = function(self)
       for _, id in ipairs(cardsMoveInfo.ids) do
         table.insert(infos, {
           cardId = id,
-          fromArea = self:getCardArea(id),
-          fromSpecialName = cardsMoveInfo.from and self:getPlayerById(cardsMoveInfo.from):getPileNameOfId(id),
+          fromArea = room:getCardArea(id),
+          fromSpecialName = cardsMoveInfo.from and room:getPlayerById(cardsMoveInfo.from):getPileNameOfId(id),
         })
       end
 
@@ -48,11 +48,11 @@ GameEvent.functions[GameEvent.MoveCards] = function(self)
     return false
   end
 
-  if self.logic:trigger(fk.BeforeCardsMove, nil, cardsMoveStructs) then
-    self.logic:breakEvent(false)
+  if room.logic:trigger(fk.BeforeCardsMove, nil, cardsMoveStructs) then
+    room.logic:breakEvent(false)
   end
 
-  self:notifyMoveCards(nil, cardsMoveStructs)
+  room:notifyMoveCards(nil, cardsMoveStructs)
 
   for _, data in ipairs(cardsMoveStructs) do
     if #data.moveInfo > 0 then
@@ -60,49 +60,49 @@ GameEvent.functions[GameEvent.MoveCards] = function(self)
 
       ---@param info MoveInfo
       for _, info in ipairs(data.moveInfo) do
-        local realFromArea = self:getCardArea(info.cardId)
+        local realFromArea = room:getCardArea(info.cardId)
         local playerAreas = { Player.Hand, Player.Equip, Player.Judge, Player.Special }
 
         if table.contains(playerAreas, realFromArea) and data.from then
-          local from = self:getPlayerById(data.from)
+          local from = room:getPlayerById(data.from)
           from:removeCards(realFromArea, { info.cardId }, info.fromSpecialName)
 
         elseif realFromArea ~= Card.Unknown then
           local fromAreaIds = {}
           if realFromArea == Card.Processing then
-            fromAreaIds = self.processing_area
+            fromAreaIds = room.processing_area
           elseif realFromArea == Card.DrawPile then
-            fromAreaIds = self.draw_pile
+            fromAreaIds = room.draw_pile
           elseif realFromArea == Card.DiscardPile then
-            fromAreaIds = self.discard_pile
+            fromAreaIds = room.discard_pile
           elseif realFromArea == Card.Void then
-            fromAreaIds = self.void
+            fromAreaIds = room.void
           end
 
           table.removeOne(fromAreaIds, info.cardId)
         end
 
         if table.contains(playerAreas, data.toArea) and data.to then
-          local to = self:getPlayerById(data.to)
+          local to = room:getPlayerById(data.to)
           to:addCards(data.toArea, { info.cardId }, data.specialName)
 
         else
           local toAreaIds = {}
           if data.toArea == Card.Processing then
-            toAreaIds = self.processing_area
+            toAreaIds = room.processing_area
           elseif data.toArea == Card.DrawPile then
-            toAreaIds = self.draw_pile
+            toAreaIds = room.draw_pile
           elseif data.toArea == Card.DiscardPile then
-            toAreaIds = self.discard_pile
+            toAreaIds = room.discard_pile
           elseif data.toArea == Card.Void then
-            toAreaIds = self.void
+            toAreaIds = room.void
           end
 
           if data.toArea == Card.DrawPile then
             local putIndex = data.drawPilePosition or 1
             if putIndex == -1 then
-              putIndex = #self.draw_pile + 1
-            elseif putIndex < 1 or putIndex > #self.draw_pile + 1 then
+              putIndex = #room.draw_pile + 1
+            elseif putIndex < 1 or putIndex > #room.draw_pile + 1 then
               putIndex = 1
             end
 
@@ -111,13 +111,13 @@ GameEvent.functions[GameEvent.MoveCards] = function(self)
             table.insert(toAreaIds, info.cardId)
           end
         end
-        self:setCardArea(info.cardId, data.toArea, data.to)
+        room:setCardArea(info.cardId, data.toArea, data.to)
         if data.toArea == Card.DrawPile or realFromArea == Card.DrawPile then
-          self:doBroadcastNotify("UpdateDrawPile", #self.draw_pile)
+          room:doBroadcastNotify("UpdateDrawPile", #room.draw_pile)
         end
 
         if not (data.to and data.toArea ~= Card.PlayerHand) then
-          Fk:filterCard(info.cardId, self:getPlayerById(data.to))
+          Fk:filterCard(info.cardId, room:getPlayerById(data.to))
         end
 
         local currentCard = Fk:getCardById(info.cardId)
@@ -126,17 +126,17 @@ GameEvent.functions[GameEvent.MoveCards] = function(self)
           realFromArea == Player.Hand and
           data.from
           then
-            self:setCardMark(currentCard, name, 0)
+            room:setCardMark(currentCard, name, 0)
           end
         end
         if
           data.toArea == Player.Equip and
           currentCard.type == Card.TypeEquip and
           data.to ~= nil and
-          self:getPlayerById(data.to):isAlive() and
+          room:getPlayerById(data.to):isAlive() and
           currentCard.equip_skill
         then
-          currentCard:onInstall(self, self:getPlayerById(data.to))
+          currentCard:onInstall(room, room:getPlayerById(data.to))
         end
 
         if
@@ -145,12 +145,12 @@ GameEvent.functions[GameEvent.MoveCards] = function(self)
           data.from ~= nil and
           currentCard.equip_skill
         then
-          currentCard:onUninstall(self, self:getPlayerById(data.from))
+          currentCard:onUninstall(room, room:getPlayerById(data.from))
         end
       end
     end
   end
 
-  self.logic:trigger(fk.AfterCardsMove, nil, cardsMoveStructs)
+  room.logic:trigger(fk.AfterCardsMove, nil, cardsMoveStructs)
   return true
 end

--- a/lua/server/room.lua
+++ b/lua/server/room.lua
@@ -91,6 +91,7 @@ function Room:initialize(_room)
   self.skill_costs = {}
   self.card_marks = {}
   self.filtered_cards = {}
+  self.printed_cards = {}
 
   self.settings = json.decode(self.room:settings())
   self.disabled_packs = self.settings.disabledPack
@@ -3180,6 +3181,20 @@ function Room:canMoveCardInBoard(flag, players, excludeIds)
   end)
 
   return targets
+end
+
+--- 现场印卡。当然了，这个卡只和这个房间有关。
+---@param name string @ 牌名
+---@param suit Suit|nil @ 花色
+---@param number integer|nil @ 点数
+---@return Card
+function Room:printCard(name, suit, number)
+  local cd = Fk:cloneCard(name, suit, number)
+  Fk:_addPrintedCard(cd)
+  table.insert(self.void, cd.id)
+  self:setCardArea(cd.id, Card.Void, nil)
+  self:doBroadcastNotify("PrintCard", json.encode{ name, suit, number })
+  return cd
 end
 
 function Room:updateQuestSkillState(player, skillName, failed)

--- a/lua/server/system_enum.lua
+++ b/lua/server/system_enum.lua
@@ -192,12 +192,12 @@ fk.ReasonJudge = 11
 
 ---@class LogMessage
 ---@field public type string
----@field public from integer
----@field public to integer[]
----@field public card integer[]
----@field public arg any
----@field public arg2 any
----@field public arg3 any
+---@field public from integer | nil
+---@field public to integer[] | nil
+---@field public card integer[] | nil
+---@field public arg any | nil
+---@field public arg2 any | nil
+---@field public arg3 any | nil
 
 ---@class SkillUseStruct
 ---@field public skill Skill

--- a/packages/test/init.lua
+++ b/packages/test/init.lua
@@ -41,12 +41,12 @@ local cheat = fk.CreateActiveSkill{
     end
 
     local cardName = room:askForChoice(from, allCardNames, "cheat")
-    local toGain = nil
-    if #allCardMapper[cardName] > 0 then
-      toGain = allCardMapper[cardName][math.random(1, #allCardMapper[cardName])]
-    end
+    local toGain = room:printCard(cardName, Card.Heart, 1)
+    -- if #allCardMapper[cardName] > 0 then
+    --   toGain = allCardMapper[cardName][math.random(1, #allCardMapper[cardName])]
+    -- end
 
-    from:addToPile(self.name, toGain, true, self.name)
+    -- from:addToPile(self.name, toGain, true, self.name)
     -- room:setCardMark(Fk:getCardById(toGain), "@@test_cheat-phase", 1)
     -- room:setCardMark(Fk:getCardById(toGain), "@@test_cheat-inhand", 1)
     room:obtainCard(effect.from, toGain, true, fk.ReasonPrey)
@@ -323,7 +323,7 @@ Fk:loadTranslationTable{
   [":test_filter"] = "你的点数大于11的牌视为无中生有。",
   ["mouxusheng"] = "谋徐盛",
   -- ["cheat"] = "小开",
-  [":cheat"] = "出牌阶段，你可以获得一张想要的牌。",
+  [":cheat"] = "出牌阶段，你可以以红桃A打印一张想要的牌并获得之。",
   ["#cheat"] = "cheat：你可以获得一张想要的牌",
   -- ["@@test_cheat-phase"] = "苦肉",
   -- ["@@test_cheat-inhand"] = "连营",

--- a/src/network/router.cpp
+++ b/src/network/router.cpp
@@ -284,7 +284,7 @@ void Router::handlePacket(const QByteArray &rawPacket) {
         } else if (command == "KickPlayer") {
           int i = jsonData.toInt();
           auto p = room->findPlayer(i);
-          if (p) room->removePlayer(p);
+          if (p && !room->isStarted()) room->removePlayer(p);
         } else if (command == "Ready") {
           player->setReady(!player->isReady());
           room->doBroadcastNotify(room->getPlayers(), "ReadyChanged",

--- a/src/server/room.cpp
+++ b/src/server/room.cpp
@@ -541,7 +541,7 @@ void Room::gameOver() {
       if (p->getState() == Player::Offline) {
         auto pid = p->getId();
         addRunRate(pid, mode);
-        addRunRate(pid, mode);
+        // addRunRate(pid, mode);
         server->temporarilyBan(pid);
       }
       p->deleteLater();


### PR DESCRIPTION
- 15秒后其他人可以将房主踢出
- event中的从room.lua复制过来的self都规范成room
- 删了feasible的deprecate警告
- 虚空印卡

关于虚空印卡的说明：
* 印的卡id为负数，但依然属于实体卡。
* 这也就是说今后判断虚拟牌的依据是id == 0而不是 <= 0。
* 不过其实虚拟牌的id自古以来就固定是0啦，所以不用担心。
* 虚空印的卡自然只和当前运行的房间有关。
* 虚空印卡的id从-2开始，每印一张其id便减少1。
* 之所以不从-1开始是因为UI把-1认定为未知牌。Bot的玩家id也从-2开始，这是一个道理。
* 除此之外，印出的卡就如同一张普通的实体卡一样，洗入牌堆啥的都没问题，用来作其他虚拟卡的子卡也没啥问题。
* 坐等后面测试出bug吧，当然我希望直接不出bug。