### PR TITLE
禅与bugfix

### DIFF
--- a/Fk/RoomElement/DetailedCheckBox.qml
+++ b/Fk/RoomElement/DetailedCheckBox.qml
@@ -39,6 +39,7 @@ GraphicsBox {
         id: choicetitle
         width: parent.width
         text: luatr(modelData)
+        triggered: root.result.indexOf(index) !== -1
         enabled: options.indexOf(modelData) !== -1
                  && (root.result.length < max_num || triggered)
         textFont.pixelSize: 24

--- a/Fk/RoomElement/DetailedCheckBox.qml
+++ b/Fk/RoomElement/DetailedCheckBox.qml
@@ -39,7 +39,7 @@ GraphicsBox {
         id: choicetitle
         width: parent.width
         text: luatr(modelData)
-        triggered: root.result.indexOf(index) !== -1
+        triggered: root.result.includes(index)
         enabled: options.indexOf(modelData) !== -1
                  && (root.result.length < max_num || triggered)
         textFont.pixelSize: 24

--- a/lua/core/card.lua
+++ b/lua/core/card.lua
@@ -149,7 +149,7 @@ function Card:clone(suit, number)
   return newCard
 end
 
---- 检测是否为虚拟卡牌，如果其ID为0及以下，则为虚拟卡牌。
+--- 检测是否为虚拟卡牌，如果其ID为0，则为虚拟卡牌。
 function Card:isVirtual()
   return self.id == 0
 end

--- a/lua/core/card.lua
+++ b/lua/core/card.lua
@@ -24,7 +24,7 @@
 ---@field public special_skills? string[] @ 衍生技能，如重铸
 ---@field public is_damage_card boolean @ 是否为会造成伤害的牌
 ---@field public multiple_targets boolean @ 是否为指定多个目标的牌
----@field public is_passive boolean @ 是否只能在响应时使用或打出
+---@field public is_passive? boolean @ 是否只能在响应时使用或打出
 ---@field public is_derived? boolean @ 判断是否为衍生牌
 local Card = class("Card")
 

--- a/lua/core/card.lua
+++ b/lua/core/card.lua
@@ -24,6 +24,7 @@
 ---@field public special_skills? string[] @ 衍生技能，如重铸
 ---@field public is_damage_card boolean @ 是否为会造成伤害的牌
 ---@field public multiple_targets boolean @ 是否为指定多个目标的牌
+---@field public is_passive boolean @ 是否只能在响应时使用或打出
 ---@field public is_derived? boolean @ 判断是否为衍生牌
 local Card = class("Card")
 
@@ -145,6 +146,7 @@ function Card:clone(suit, number)
   newCard.special_skills = self.special_skills
   newCard.is_damage_card = self.is_damage_card
   newCard.multiple_targets = self.multiple_targets
+  newCard.is_passive = self.is_passive
   newCard.is_derived = self.is_derived
   return newCard
 end

--- a/lua/core/player.lua
+++ b/lua/core/player.lua
@@ -860,9 +860,21 @@ end
 
 --- 确认玩家是否可以使用特定牌。
 ---@param card Card @ 特定牌
-function Player:canUse(card)
+---@param extra_data? UseExtraData @ 额外数据
+function Player:canUse(card, extra_data)
   assert(card, "Error: No Card")
-  return card.skill:canUse(self, card)
+  return card.skill:canUse(self, card, extra_data)
+end
+
+--- 确认玩家是否可以对特定玩家使用特定牌。
+---@param card Card @ 特定牌
+---@param to Player @ 特定玩家
+---@param extra_data? UseExtraData @ 额外数据
+function Player:canUseCardTo(card, to, extra_data)
+  if self:prohibitUse(card) or self:isProhibited(to, card) then return false end
+  local distance_limited = not (extra_data and extra_data.bypass_distances)
+  local can_use = self:canUse(card, extra_data)
+  return can_use and card.skill:modTargetFilter(to.id, {}, self.id, card, distance_limited)
 end
 
 --- 确认玩家是否被禁止对特定玩家使用特定牌。

--- a/lua/core/player.lua
+++ b/lua/core/player.lua
@@ -874,7 +874,6 @@ end
 ---@param card Card @ 特定牌
 ---@param extra_data? UseExtraData @ 额外数据
 function Player:canUse(card, extra_data)
-  assert(card, "Error: No Card")
   return card.skill:canUse(self, card, extra_data)
 end
 
@@ -882,7 +881,7 @@ end
 ---@param card Card @ 特定牌
 ---@param to Player @ 特定玩家
 ---@param extra_data? UseExtraData @ 额外数据
-function Player:canUseCardTo(card, to, extra_data)
+function Player:canUseTo(card, to, extra_data)
   if self:prohibitUse(card) or self:isProhibited(to, card) then return false end
   local distance_limited = not (extra_data and extra_data.bypass_distances)
   local can_use = self:canUse(card, extra_data)

--- a/lua/core/skill_type/usable_skill.lua
+++ b/lua/core/skill_type/usable_skill.lua
@@ -4,6 +4,7 @@
 ---@field public main_skill UsableSkill
 ---@field public max_use_time integer[]
 ---@field public expand_pile? string | integer[] | fun(self: UsableSkill): integer[]|string?
+---@field public hooked_piles? string | string[]
 local UsableSkill = Skill:subclass("UsableSkill")
 
 function UsableSkill:initialize(name, frequency)

--- a/lua/core/skill_type/usable_skill.lua
+++ b/lua/core/skill_type/usable_skill.lua
@@ -4,7 +4,7 @@
 ---@field public main_skill UsableSkill
 ---@field public max_use_time integer[]
 ---@field public expand_pile? string | integer[] | fun(self: UsableSkill): integer[]|string?
----@field public hooked_piles? string | string[]
+---@field public derived_piles? string | string[]
 local UsableSkill = Skill:subclass("UsableSkill")
 
 function UsableSkill:initialize(name, frequency)

--- a/lua/fk_ex.lua
+++ b/lua/fk_ex.lua
@@ -48,10 +48,10 @@ end
 local function readUsableSpecToSkill(skill, spec)
   readCommonSpecToSkill(skill, spec)
   assert(spec.main_skill == nil or spec.main_skill:isInstanceOf(UsableSkill))
-  if type(spec.hooked_piles) == "string" then
-    skill.hooked_piles = {spec.hooked_piles}
+  if type(spec.derived_piles) == "string" then
+    skill.derived_piles = {spec.derived_piles}
   else
-    skill.hooked_piles = spec.hooked_piles or {}
+    skill.derived_piles = spec.derived_piles or {}
   end
   skill.main_skill = spec.main_skill
   skill.target_num = spec.target_num or skill.target_num

--- a/lua/fk_ex.lua
+++ b/lua/fk_ex.lua
@@ -444,6 +444,7 @@ end
 ---@field public special_skills? string[]
 ---@field public is_damage_card? boolean
 ---@field public multiple_targets? boolean
+---@field public is_passive? boolean
 
 local defaultCardSkill = fk.CreateActiveSkill{
   name = "default_card_skill",
@@ -486,6 +487,7 @@ local function readCardSpecToCard(card, spec)
   card.special_skills = spec.special_skills
   card.is_damage_card = spec.is_damage_card
   card.multiple_targets = spec.multiple_targets
+  card.is_passive = spec.is_passive
 end
 
 ---@param spec CardSpec

--- a/lua/fk_ex.lua
+++ b/lua/fk_ex.lua
@@ -195,8 +195,8 @@ function fk.CreateActiveSkill(spec)
   readUsableSpecToSkill(skill, spec)
 
   if spec.can_use then
-    skill.canUse = function(curSkill, player, card)
-      return spec.can_use(curSkill, player, card) and curSkill:isEffectable(player)
+    skill.canUse = function(curSkill, player, card, extra_data)
+      return spec.can_use(curSkill, player, card, extra_data) and curSkill:isEffectable(player)
     end
   end
   if spec.card_filter then skill.cardFilter = spec.card_filter end

--- a/lua/fk_ex.lua
+++ b/lua/fk_ex.lua
@@ -48,6 +48,11 @@ end
 local function readUsableSpecToSkill(skill, spec)
   readCommonSpecToSkill(skill, spec)
   assert(spec.main_skill == nil or spec.main_skill:isInstanceOf(UsableSkill))
+  if type(spec.hooked_piles) == "string" then
+    skill.hooked_piles = {spec.hooked_piles}
+  else
+    skill.hooked_piles = spec.hooked_piles or {}
+  end
   skill.main_skill = spec.main_skill
   skill.target_num = spec.target_num or skill.target_num
   skill.min_target_num = spec.min_target_num or skill.min_target_num

--- a/lua/fk_ex.lua
+++ b/lua/fk_ex.lua
@@ -214,9 +214,9 @@ function fk.CreateActiveSkill(spec)
 
   if spec.interaction then
     skill.interaction = setmetatable({}, {
-      __call = function(self)
+      __call = function()
         if type(spec.interaction) == "function" then
-          return spec.interaction(self)
+          return spec.interaction(skill)
         else
           return spec.interaction
         end

--- a/lua/server/events/gameflow.lua
+++ b/lua/server/events/gameflow.lua
@@ -294,7 +294,7 @@ GameEvent.functions[GameEvent.Phase] = function(self)
           end
           if table.contains(player:getCardIds(Player.Judge), cid) then
             room:moveCardTo(card, Card.Processing, nil, fk.ReasonPut, self.name)
-  
+
             ---@type CardEffectEvent
             local effect_data = {
               card = card,

--- a/lua/server/events/gameflow.lua
+++ b/lua/server/events/gameflow.lua
@@ -285,11 +285,12 @@ GameEvent.functions[GameEvent.Phase] = function(self)
       end,
       [Player.Judge] = function()
         local cards = player:getCardIds(Player.Judge)
-        for i = #cards, 1, -1 do
-          local card
-          card = player:removeVirtualEquip(cards[i])
+        while #cards > 0 do
+          local cid = table.remove(cards)
+          if not cid then return end
+          local card = player:removeVirtualEquip(cid)
           if not card then
-            card = Fk:getCardById(cards[i])
+            card = Fk:getCardById(cid)
           end
           room:moveCardTo(card, Card.Processing, nil, fk.ReasonPut, self.name)
 

--- a/lua/server/events/gameflow.lua
+++ b/lua/server/events/gameflow.lua
@@ -268,7 +268,7 @@ GameEvent.functions[GameEvent.Phase] = function(self)
   local room = self.room
   local logic = room.logic
 
-  local player = self.data[1]
+  local player = self.data[1] ---@type Player
   if not logic:trigger(fk.EventPhaseStart, player) then
     if player.phase ~= Player.NotActive then
       logic:trigger(fk.EventPhaseProceeding, player)
@@ -292,17 +292,19 @@ GameEvent.functions[GameEvent.Phase] = function(self)
           if not card then
             card = Fk:getCardById(cid)
           end
-          room:moveCardTo(card, Card.Processing, nil, fk.ReasonPut, self.name)
-
-          ---@type CardEffectEvent
-          local effect_data = {
-            card = card,
-            to = player.id,
-            tos = { {player.id} },
-          }
-          room:doCardEffect(effect_data)
-          if effect_data.isCancellOut and card.skill then
-            card.skill:onNullified(room, effect_data)
+          if table.contains(player:getCardIds(Player.Judge), cid) then
+            room:moveCardTo(card, Card.Processing, nil, fk.ReasonPut, self.name)
+  
+            ---@type CardEffectEvent
+            local effect_data = {
+              card = card,
+              to = player.id,
+              tos = { {player.id} },
+            }
+            room:doCardEffect(effect_data)
+            if effect_data.isCancellOut and card.skill then
+              card.skill:onNullified(room, effect_data)
+            end
           end
         end
       end,

--- a/lua/server/mark_enum.lua
+++ b/lua/server/mark_enum.lua
@@ -19,23 +19,38 @@ MarkEnum.MinusMaxCards = "MinusMaxCards"
 ---于本回合内减少标记值数量的手牌上限
 MarkEnum.MinusMaxCardsInTurn = "MinusMaxCards-turn"
 
----使用牌无次数限制，可带清除标记后缀（-tmp为请求专用）
+---使用牌无次数限制
 MarkEnum.BypassTimesLimit = "BypassTimesLimit"
----使用牌无距离限制，可带清除标记后缀（-tmp为请求专用）
+---使用牌无距离限制
 MarkEnum.BypassDistancesLimit = "BypassDistancesLimit"
----对其使用牌无次数限制，可带清除标记后缀
+---对其使用牌无次数限制
 MarkEnum.BypassTimesLimitTo = "BypassTimesLimitTo"
----对其使用牌无距离限制，可带清除标记后缀
+---对其使用牌无距离限制
 MarkEnum.BypassDistancesLimitTo = "BypassDistancesLimitTo"
----非锁定技失效，可带清除标记后缀
+---非锁定技失效
 MarkEnum.UncompulsoryInvalidity = "UncompulsoryInvalidity"
----不可明置，可带清除标记后缀（值为表，m - 主将, d - 副将）
+---不可明置（值为表，m - 主将, d - 副将）
 MarkEnum.RevealProhibited = "RevealProhibited"
----不计入距离、座次后缀，可带清除标记后缀
+---不计入距离、座次后缀
 MarkEnum.PlayerRemoved = "PlayerRemoved"
 
 ---各种清除标记后缀
+---
+---phase：阶段结束后
+---
+---turn：回合结束后
+---
+---round：轮次结束后
 MarkEnum.TempMarkSuffix = { "-phase", "-turn", "-round" }
 
 ---卡牌标记版本的清除标记后缀
-MarkEnum.CardTempMarkSuffix = { "-phase", "-turn", "-round", "-inhand" }
+---
+---phase：阶段结束后
+---
+---turn：回合结束后
+---
+---round：轮次结束后
+---
+---inhand：离开手牌区后
+MarkEnum.CardTempMarkSuffix = { "-phase", "-turn", "-round",
+                                "-inhand" }

--- a/lua/server/room.lua
+++ b/lua/server/room.lua
@@ -2899,7 +2899,7 @@ end
 
 --- 让一名玩家获得一张牌
 ---@param player integer|ServerPlayer @ 要拿牌的玩家
----@param cid integer|Card @ 要拿到的卡牌
+---@param cid integer|Card|integer[] @ 要拿到的卡牌
 ---@param unhide? boolean @ 是否明着拿
 ---@param reason? CardMoveReason @ 卡牌移动的原因
 function Room:obtainCard(player, cid, unhide, reason)
@@ -3237,7 +3237,7 @@ function Room:retrial(card, player, judge, skillName, exchange)
 end
 
 --- 弃置一名角色的牌。
----@param card_ids integer[] @ 被弃掉的牌
+---@param card_ids integer[]|integer @ 被弃掉的牌
 ---@param skillName? string @ 技能名
 ---@param who ServerPlayer @ 被弃牌的人
 ---@param thrower? ServerPlayer @ 弃别人牌的人

--- a/lua/server/room.lua
+++ b/lua/server/room.lua
@@ -3122,8 +3122,8 @@ function Room:handleAddLoseSkills(player, skill_names, source_skill, sendlog, no
 
           table.insert(losts, true)
           table.insert(triggers, s)
-          if s.hooked_piles then
-            for _, pile_name in ipairs(s.hooked_piles) do
+          if s.derived_piles then
+            for _, pile_name in ipairs(s.derived_piles) do
               table.insertTableIfNeed(lost_piles, player:getPile(pile_name))
             end
           end
@@ -3169,7 +3169,7 @@ function Room:handleAddLoseSkills(player, skill_names, source_skill, sendlog, no
       ids = lost_piles,
       from = player.id,
       toArea = Card.DiscardPile,
-      moveReason = fk.ReasonDiscard,
+      moveReason = fk.ReasonPutIntoDiscardPile,
     })
   end
 end

--- a/lua/server/system_enum.lua
+++ b/lua/server/system_enum.lua
@@ -128,7 +128,7 @@ fk.IceDamage = 4
 ---@field public fixedAddTimesResponsors? integer[]
 
 ---@class CardEffectEvent
----@field public from integer
+---@field public from nil|integer
 ---@field public to integer
 ---@field public subTargets? integer[]
 ---@field public tos TargetGroup

--- a/lua/server/system_enum.lua
+++ b/lua/server/system_enum.lua
@@ -128,7 +128,7 @@ fk.IceDamage = 4
 ---@field public fixedAddTimesResponsors? integer[]
 
 ---@class CardEffectEvent
----@field public from nil|integer
+---@field public from? integer
 ---@field public to integer
 ---@field public subTargets? integer[]
 ---@field public tos TargetGroup

--- a/packages/standard_cards/init.lua
+++ b/packages/standard_cards/init.lua
@@ -112,6 +112,7 @@ local jink = fk.CreateBasicCard{
   suit = Card.Heart,
   number = 2,
   skill = jinkSkill,
+  is_passive = true,
 }
 
 extension:addCards({
@@ -468,6 +469,7 @@ local nullification = fk.CreateTrickCard{
   suit = Card.Spade,
   number = 11,
   skill = nullificationSkill,
+  is_passive = true,
 }
 
 extension:addCards({


### PR DESCRIPTION
- 将Utility如canUseCardTo的一些函数搬运到了本体
- 为技能添加hooked_piles属性，当失去技能时自动弃置hooked_piles内的所有私人牌堆
- 修复了添加技能没写source_skill的bug
- 修复了ActiveSkill的interaction不传入Skill本身而是metatable的bug
- 修复了主动询问canUse时没有传入extra_data的bug
- 修复了多选时按钮选项变回空白的bug
- 修复了判定阶段被中途拿走判定牌后报错的bug