### PR TITLE
Fixbug2

### DIFF
--- a/Fk/Cheat/PlayerDetail.qml
+++ b/Fk/Cheat/PlayerDetail.qml
@@ -153,6 +153,14 @@ Flickable {
         selectByMouse: false
         wrapMode: TextEdit.WordWrap
         textFormat: TextEdit.RichText
+        onLinkActivated: (link) => {
+          if (link === "back") {
+            text = savedtext.pop();
+          } else {
+            savedtext.push(text);
+            text = '<a href="back">点击返回</a><br>' + luatr(link);
+          }
+        }
       }
     }
   }

--- a/Fk/Config.qml
+++ b/Fk/Config.qml
@@ -60,11 +60,13 @@ QtObject {
   property bool enableFreeAssign: false
   property bool observing: false
   property bool replaying: false
+  property bool replayingShowCards: false
   property list<string> blockedUsers: []
   property int totalTime: 0 // FIXME: only for notifying
 
   onObservingChanged: lcall("SetObserving", observing);
-  //onReplayingChanged: lcall("SetReplaying", replaying);
+  onReplayingChanged: lcall("SetReplaying", replaying);
+  onReplayingShowCardsChanged: lcall("SetReplayingShowCards", replayingShowCards);
 
   // onDisabledGeneralsChanged: {
   //   disableGeneralSchemes[disableSchemeIdx] = disabledGenerals;

--- a/Fk/Pages/Room.qml
+++ b/Fk/Pages/Room.qml
@@ -396,6 +396,7 @@ Item {
         deputyGeneral: model.deputyGeneral
         screenName: model.screenName
         role: model.role
+        role_shown: model.role_shown
         kingdom: model.kingdom
         netstate: model.netstate
         maxHp: model.maxHp
@@ -1396,6 +1397,7 @@ Item {
         deputyGeneral: "",
         screenName: i ? "" : Self.screenName,
         role: "unknown",
+        role_shown: false,
         kingdom: "unknown",
         netstate: "online",
         maxHp: 0,

--- a/Fk/Pages/Room.qml
+++ b/Fk/Pages/Room.qml
@@ -590,6 +590,12 @@ Item {
       }
 
       Switch {
+        text: luatr("Show All Cards")
+        checked: config.replayingShowCards
+        onCheckedChanged: config.replayingShowCards = checked;
+      }
+
+      Switch {
         text: luatr("Speed Resume")
         checked: false
         onCheckedChanged: Backend.controlReplayer("uniform");

--- a/Fk/Pages/RoomLogic.js
+++ b/Fk/Pages/RoomLogic.js
@@ -208,6 +208,7 @@ function moveCards(data) {
     if (!from || !to || (from === to && move.fromArea !== Card.DiscardPile))
       continue;
     const items = from.remove(move.ids, move.fromSpecialName, data);
+    items.forEach((item) => item.known = !!data[item.cid.toString()]);
     if (to === tablePile) {
       let vanished = items.filter(c => c.cid === -1);
       if (vanished.length > 0) {

--- a/Fk/Pages/RoomLogic.js
+++ b/Fk/Pages/RoomLogic.js
@@ -1019,6 +1019,7 @@ callbacks["AskForCardChosen"] = (data) => {
 
   const box = roomScene.popupBox.item;
   box.prompt = prompt;
+  box.visible_data = data.visible_data ?? {};
   for (let d of data.card_data) {
     const arr = [];
     const ids = d[1];
@@ -1053,6 +1054,7 @@ callbacks["AskForCardsChosen"] = (data) => {
   box.min = min;
   box.max = max;
   box.prompt = prompt;
+  box.visible_data = data.visible_data ?? {};
   for (let d of data.card_data) {
     const arr = [];
     const ids = d[1];

--- a/Fk/RoomElement/HandcardArea.qml
+++ b/Fk/RoomElement/HandcardArea.qml
@@ -49,7 +49,7 @@ Item {
       card = result[i];
       card.draggable = false;
       card.selectable = false;
-      card.clicked.connect(selectCard);
+      card.clicked.disconnect(selectCard);
       card.selectedChanged.disconnect(adjustCards);
       card.released.disconnect(updateCardReleased);
       card.xChanged.disconnect(updateCardDragging);

--- a/Fk/RoomElement/Photo.qml
+++ b/Fk/RoomElement/Photo.qml
@@ -18,6 +18,7 @@ Item {
   property string deputyGeneral: ""
   property string screenName: ""
   property string role: "unknown"
+  property bool role_shown: false
   property string kingdom: "qun"
   property string netstate: "online"
   property alias handcards: handcardAreaItem.length
@@ -533,6 +534,7 @@ Item {
     id: role
     value: {
       if (root.role === "hidden") return "hidden";
+      if (root.role_shown) return root.role;
       lcall("RoleVisibility", root.playerid) ? root.role : "unknown";
     }
     anchors.top: parent.top

--- a/Fk/RoomElement/PlayerCardBox.qml
+++ b/Fk/RoomElement/PlayerCardBox.qml
@@ -25,6 +25,7 @@ GraphicsBox {
   property int min: 0
   property int max: 1
   property var selected_ids: []
+  property var visible_data: ({})
 
   ListModel {
     id: cardModel
@@ -75,7 +76,10 @@ GraphicsBox {
             suit: model.suit || ""
             number: model.number || 0
             autoBack: false
-            known: model.known
+            known: {
+              if (visible_data[cid.toString()] == false) return false;
+              return true;
+            }
             selectable: true
             onClicked: {
               if (!root.multiChoose) {

--- a/Fk/RoomElement/PoxiBox.qml
+++ b/Fk/RoomElement/PoxiBox.qml
@@ -71,7 +71,11 @@ GraphicsBox {
             suit: model.suit || ""
             number: model.number || 0
             autoBack: false
-            known: model.known
+            known: {
+              const visible_data = extra_data?.visible_data ?? {};
+              if (visible_data[cid.toString()] == false) return false;
+              return true;
+            }
             selectable: chosenInBox ||
               lcall("PoxiFilter", root.poxi_type, model.cid, root.selected_ids,
                     root.card_data, root.extra_data);


### PR DESCRIPTION
* 修复录像可见性问题 并增加查看未知牌功能
* 给qml绑定上role_shown属性，以便更新
* 修复从非隐藏卡牌区域删除卡牌时卡牌的known不受moveData干涉
* 给askForCardChosen和poxi贴了个visible_data
* 修复捡垃圾会导致手牌重复触发onClicked
