### PR TITLE
fix: TestEngine.testTranslate when computer not in zh-cn

### DIFF
--- a/test/lua/core/engine.lua
+++ b/test/lua/core/engine.lua
@@ -20,7 +20,7 @@ function TestEngine:testLoadPackages()
 end
 
 function TestEngine:testTranslate()
-  lu.assertEquals(Fk:translate("caocao"), "曹操")
+  lu.assertEquals(Fk:translate("caocao", "zh_CN"), "曹操")
 end
 
 function TestEngine:teardownClass()


### PR DESCRIPTION
fix failed test: (the computer is a mac os x with `LANG=en_US.UTF-8`)
```
1) TestEngine.testTranslate
test/lua/core/engine.lua:23: expected: "曹操"
actual: "Cao Cao"
```